### PR TITLE
Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 crowdstrike-falconpy>=1.0.0
+humiolib
+python-dateutil


### PR DESCRIPTION
Adds the missing `humiolib` and `python-dateutil` dependencies.